### PR TITLE
refactor: index params in vault events

### DIFF
--- a/src/interfaces/IEarnVault.sol
+++ b/src/interfaces/IEarnVault.sol
@@ -29,19 +29,19 @@ interface IEarnVault is INFTPermissions {
 
   /// @notice Emitted when a new position is created
   event PositionCreated(
-    uint256 positionId,
+    uint256 indexed positionId,
+    address indexed owner,
     StrategyId strategyId,
     uint256 assetsDeposited,
-    address owner,
     INFTPermissions.PermissionSet[] permissions,
     bytes misc
   );
 
   /// @notice Emitted when a new position is increased
-  event PositionIncreased(uint256 positionId, uint256 assetsDeposited);
+  event PositionIncreased(uint256 indexed positionId, uint256 assetsDeposited);
 
   /// @notice Emitted when a new position is withdrawn
-  event PositionWithdrawn(uint256 positionId, address[] tokens, uint256[] withdrawn, address recipient);
+  event PositionWithdrawn(uint256 indexed positionId, address[] tokens, uint256[] withdrawn, address recipient);
 
   /**
    * @notice Returns the role in charge of pausing/unpausing deposits

--- a/src/vault/EarnVault.sol
+++ b/src/vault/EarnVault.sol
@@ -179,7 +179,7 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
       depositAmount: depositAmount
     });
 
-    emit PositionCreated(positionId, strategyId, assetsDeposited, owner, permissions, misc);
+    emit PositionCreated(positionId, owner, strategyId, assetsDeposited, permissions, misc);
   }
 
   /// @inheritdoc IEarnVault

--- a/test/unit/vault/EarnVault.t.sol
+++ b/test/unit/vault/EarnVault.t.sol
@@ -36,17 +36,17 @@ contract EarnVaultTest is PRBTest, StdUtils {
   using Math for uint104;
 
   event PositionCreated(
-    uint256 positionId,
+    uint256 indexed positionId,
+    address indexed owner,
     StrategyId strategyId,
     uint256 assetsDeposited,
-    address owner,
     INFTPermissions.PermissionSet[] permissions,
     bytes misc
   );
 
-  event PositionIncreased(uint256 positionId, uint256 assetsDeposited);
+  event PositionIncreased(uint256 indexed positionId, uint256 assetsDeposited);
 
-  event PositionWithdrawn(uint256 positionId, address[] tokens, uint256[] withdrawn, address recipient);
+  event PositionWithdrawn(uint256 indexed positionId, address[] tokens, uint256[] withdrawn, address recipient);
 
   using StrategyUtils for EarnStrategyRegistryMock;
   using InternalUtils for INFTPermissions.Permission[];
@@ -208,7 +208,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       1
     );
     vm.expectEmit();
-    emit PositionCreated(1, strategyId, amountToDeposit, positionOwner, permissions, misc);
+    emit PositionCreated(1, positionOwner, strategyId, amountToDeposit, permissions, misc);
     (uint256 positionId, uint256 assetsDeposited) = vault.createPosition{ value: amountToDeposit }(
       strategyId, Token.NATIVE_TOKEN, amountToDeposit, positionOwner, permissions, creationData, misc
     );
@@ -248,7 +248,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       address(strategy), abi.encodeWithSelector(IEarnStrategy.deposited.selector, address(erc20), amountToDeposit), 1
     );
     vm.expectEmit();
-    emit PositionCreated(1, strategyId, amountToDeposit, positionOwner, permissions, misc);
+    emit PositionCreated(1, positionOwner, strategyId, amountToDeposit, permissions, misc);
     (uint256 positionId, uint256 assetsDeposited) =
       vault.createPosition(strategyId, address(erc20), amountToDeposit, positionOwner, permissions, creationData, misc);
 
@@ -290,7 +290,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       address(strategy), abi.encodeWithSelector(IEarnStrategy.deposited.selector, address(erc20), amountToDeposit), 1
     );
     vm.expectEmit();
-    emit PositionCreated(1, strategyId, amountToDeposit, positionOwner, permissions, misc);
+    emit PositionCreated(1, positionOwner, strategyId, amountToDeposit, permissions, misc);
     (uint256 positionId, uint256 assetsDeposited) = vault.createPosition(
       strategyId, address(erc20), type(uint256).max, positionOwner, permissions, creationData, misc
     );


### PR DESCRIPTION
We are now marking some event params as `indexed`. 
We focused on `owner` first so that we can figure out all positions owned by an address. 
Once we have those position ids, we will be able to find all of their events by having indexed `positionId`