### PR TITLE
refactor: add more context to special withdraw

### DIFF
--- a/src/interfaces/IEarnStrategy.sol
+++ b/src/interfaces/IEarnStrategy.sol
@@ -166,20 +166,29 @@ interface IEarnStrategy is IERC165 {
    * @dev Can only be called by the vault
    * @param positionId The position that initiated the withdrawal
    * @param withdrawalCode The code that identifies the type of withdrawal
+   * @param toWithdraw Amounts to withdraw, based on the withdrawal code. Does not need to have the same
+   *                   length or order as `tokens`
    * @param withdrawalData Data necessary to execute the withdrawal
    * @param recipient The account that will receive the tokens
-   * @return withdrawn How much was withdrawn from each token, in the same order as `tokens`
-   * @return withdrawalTypes The types of withdrawals for each token, in the same order as `tokens`
+   * @return balanceChanges Changes in the position's balances
+   * @return actualWithdrawnTokens The tokens that were actually withdrawn
+   * @return actualWithdrawnAmounts How much was withdrawn from each token
    * @return result Some custom data related to the withdrawal
    */
   function specialWithdraw(
     uint256 positionId,
     SpecialWithdrawalCode withdrawalCode,
+    uint256[] calldata toWithdraw,
     bytes calldata withdrawalData,
     address recipient
   )
     external
-    returns (uint256[] memory withdrawn, WithdrawalType[] memory withdrawalTypes, bytes memory result);
+    returns (
+      uint256[] memory balanceChanges,
+      address[] memory actualWithdrawnTokens,
+      uint256[] memory actualWithdrawnAmounts,
+      bytes memory result
+    );
 
   /**
    * @notice Migrates all tokens and data to a new strategy

--- a/src/interfaces/IEarnVault.sol
+++ b/src/interfaces/IEarnVault.sol
@@ -176,16 +176,20 @@ interface IEarnVault is INFTPermissions {
    * @dev The caller must have permissions to withdraw from the position
    * @param positionId The position to withdraw funds from
    * @param withdrawalCode The code that identifies the special withdrawal
+   * @param toWithdraw Amounts to withdraw, based on the withdrawal code. Does not need to have the same
+   *                   length or order as `tokens`
    * @param withdrawalData The data that defines the withdrawal
    * @param recipient The account that will receive the withdrawn funds
    * @return tokens All of the position's tokens
-   * @return withdrawn How much was actually withdrawn from each token
-   * @return withdrawalTypes The type of withdrawal for each token
+   * @return balanceChanges Changes in the position's balances, in the same order as `tokens`
+   * @return actualWithdrawnTokens The tokens that were actually withdrawn
+   * @return actualWithdrawnAmounts How much was withdrawn from each token
    * @return result The result of the withdrawal. Can be different for each strategy
    */
   function specialWithdraw(
     uint256 positionId,
     SpecialWithdrawalCode withdrawalCode,
+    uint256[] calldata toWithdraw,
     bytes calldata withdrawalData,
     address recipient
   )
@@ -193,8 +197,9 @@ interface IEarnVault is INFTPermissions {
     payable
     returns (
       address[] memory tokens,
-      uint256[] memory withdrawn,
-      IEarnStrategy.WithdrawalType[] memory withdrawalTypes,
+      uint256[] memory balanceChanges,
+      address[] memory actualWithdrawnTokens,
+      uint256[] memory actualWithdrawnAmounts,
       bytes memory result
     );
 

--- a/src/types/SpecialWithdrawals.sol
+++ b/src/types/SpecialWithdrawals.sol
@@ -27,19 +27,11 @@ function notEquals(SpecialWithdrawalCode code1, SpecialWithdrawalCode code2) pur
 library SpecialWithdrawal {
   /*
    * Withdraws the asset's farm token directly, by specifying the amount of farm tokens to withdraw
-   * Input: 
-   * - uint256: amount of farm tokens to withdraw
-   * Output: 
-   * - uint256: amount of assets withdrawn
    */
   SpecialWithdrawalCode internal constant WITHDRAW_ASSET_FARM_TOKEN_BY_AMOUNT = SpecialWithdrawalCode.wrap(0);
 
   /*
    * Withdraws the asset's farm token directly, by specifying the equivalent in terms of the asset
-   * Input: 
-   * - uint256: amount of assets to withdraw
-   * Output: 
-   * - uint256: amount of farm tokens withdrawn
    */
   SpecialWithdrawalCode internal constant WITHDRAW_ASSET_FARM_TOKEN_BY_ASSET_AMOUNT = SpecialWithdrawalCode.wrap(1);
 }

--- a/test/gas/vault/Gas_EarnVault_OneToken_OnePosition.t.sol
+++ b/test/gas/vault/Gas_EarnVault_OneToken_OnePosition.t.sol
@@ -64,7 +64,9 @@ contract GasEarnVaultOneTokenOnePosition is BaseEarnVaultGasTest {
   }
 
   function test_Gas_specialWithdraw() public {
-    vault.specialWithdraw(positionId, SpecialWithdrawalCode.wrap(0), abi.encode(0, amountToWithdraw), address(this));
+    vault.specialWithdraw(
+      positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), address(this)
+    );
   }
 
   function test_Gas_increasePosition_WithNative() public {

--- a/test/gas/vault/Gas_EarnVault_TwoTokens_OnePosition.t.sol
+++ b/test/gas/vault/Gas_EarnVault_TwoTokens_OnePosition.t.sol
@@ -50,7 +50,9 @@ contract GasEarnVaultTwoTokensOnePosition is BaseEarnVaultGasTest {
   }
 
   function test_Gas_specialWithdraw() public {
-    vault.specialWithdraw(positionId, SpecialWithdrawalCode.wrap(0), abi.encode(0, amountToWithdraw), address(this));
+    vault.specialWithdraw(
+      positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), address(this)
+    );
   }
 
   function test_Gas_increasePosition() public {

--- a/test/invariant/vault/handlers/VaultHandler.sol
+++ b/test/invariant/vault/handlers/VaultHandler.sol
@@ -9,6 +9,7 @@ import { IEarnVault, StrategyId } from "../../../../src/vault/EarnVault.sol";
 import { SpecialWithdrawalCode } from "../../../../src/types/SpecialWithdrawals.sol";
 
 import { EarnStrategyCustomBalanceMock } from "../../../mocks/strategies/EarnStrategyCustomBalanceMock.sol";
+import { CommonUtils } from "../../../utils/CommonUtils.sol";
 // solhint-disable no-empty-blocks
 // solhint-disable reason-string
 
@@ -79,7 +80,8 @@ contract VaultHandler is StdUtils {
         _vault.specialWithdraw({
           positionId: positionId,
           withdrawalCode: SpecialWithdrawalCode.wrap(0),
-          withdrawalData: abi.encode(tokenIndex, amountToWithdraw),
+          toWithdraw: CommonUtils.arrayOf(amountToWithdraw),
+          withdrawalData: abi.encode(tokenIndex),
           recipient: address(1)
         });
       }

--- a/test/mocks/strategies/EarnStrategyCustomBalanceMock.sol
+++ b/test/mocks/strategies/EarnStrategyCustomBalanceMock.sol
@@ -63,19 +63,28 @@ contract EarnStrategyCustomBalanceMock is EarnStrategyDead {
   function specialWithdraw(
     uint256,
     SpecialWithdrawalCode,
+    uint256[] calldata toWithdraw,
     bytes calldata withdrawData,
     address
   )
     external
     override
-    returns (uint256[] memory withdrawn, WithdrawalType[] memory types, bytes memory data)
+    returns (
+      uint256[] memory balanceChanges,
+      address[] memory actualWithdrawnTokens,
+      uint256[] memory actualWithdrawnAmounts,
+      bytes memory data
+    )
   {
     // Withdraw specific token
-    (uint256 tokenIndex, uint256 toWithdraw) = abi.decode(withdrawData, (uint256, uint256));
-    tokenBalance[_tokens.values()[tokenIndex]] -= toWithdraw.toUint104();
-    withdrawn = new uint256[](_tokens.length());
-    withdrawn[tokenIndex] = toWithdraw;
-    types = new WithdrawalType[](_tokens.length());
+    (uint256 tokenIndex) = abi.decode(withdrawData, (uint256));
+    tokenBalance[_tokens.values()[tokenIndex]] -= toWithdraw[0].toUint104();
+    balanceChanges = new uint256[](_tokens.length());
+    balanceChanges[tokenIndex] = toWithdraw[0];
+    actualWithdrawnTokens = new address[](1);
+    actualWithdrawnTokens[0] = _tokens.values()[tokenIndex];
+    actualWithdrawnAmounts = new uint256[](1);
+    actualWithdrawnAmounts[0] = toWithdraw[0];
     data = "0x";
   }
 

--- a/test/mocks/strategies/EarnStrategyDead.sol
+++ b/test/mocks/strategies/EarnStrategyDead.sol
@@ -92,12 +92,13 @@ contract EarnStrategyDead is IEarnStrategy {
   function specialWithdraw(
     uint256,
     SpecialWithdrawalCode,
+    uint256[] calldata,
     bytes calldata,
     address
   )
     external
     virtual
-    returns (uint256[] memory, WithdrawalType[] memory, bytes memory)
+    returns (uint256[] memory, address[] memory, uint256[] memory, bytes memory)
   {
     revert NotImplemented();
   }

--- a/test/mocks/strategies/EarnStrategyStateBalanceMock.sol
+++ b/test/mocks/strategies/EarnStrategyStateBalanceMock.sol
@@ -73,23 +73,32 @@ contract EarnStrategyStateBalanceMock is EarnStrategyDead {
   function specialWithdraw(
     uint256,
     SpecialWithdrawalCode,
+    uint256[] calldata toWithdraw,
     bytes calldata withdrawData,
     address recipient
   )
     external
     override
-    returns (uint256[] memory withdrawn, WithdrawalType[] memory types, bytes memory data)
+    returns (
+      uint256[] memory balanceChanges,
+      address[] memory actualWithdrawnTokens,
+      uint256[] memory actualWithdrawnAmounts,
+      bytes memory data
+    )
   {
     // Withdraw specific token
-    (uint256 tokenIndex, uint256 toWithdraw) = abi.decode(withdrawData, (uint256, uint256));
+    (uint256 tokenIndex) = abi.decode(withdrawData, (uint256));
     if (tokens[tokenIndex] == Token.NATIVE_TOKEN) {
-      Address.sendValue(payable(recipient), toWithdraw);
+      Address.sendValue(payable(recipient), toWithdraw[0]);
     } else {
-      IERC20(tokens[tokenIndex]).transfer(recipient, toWithdraw);
+      IERC20(tokens[tokenIndex]).transfer(recipient, toWithdraw[0]);
     }
-    withdrawn = new uint256[](tokens.length);
-    withdrawn[tokenIndex] = toWithdraw;
-    types = new WithdrawalType[](tokens.length);
+    balanceChanges = new uint256[](tokens.length);
+    balanceChanges[tokenIndex] = toWithdraw[0];
+    actualWithdrawnTokens = new address[](1);
+    actualWithdrawnTokens[0] = tokens[tokenIndex];
+    actualWithdrawnAmounts = new uint256[](1);
+    actualWithdrawnAmounts[0] = toWithdraw[0];
     data = "0x";
   }
 

--- a/test/unit/vault/EarnVault.t.sol
+++ b/test/unit/vault/EarnVault.t.sol
@@ -1470,7 +1470,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     vm.prank(operator);
     vm.expectEmit();
     emit PositionWithdrawn(positionId, tokens, CommonUtils.arrayOf(amountToWithdraw), recipient);
-    vault.specialWithdraw(positionId, SpecialWithdrawalCode.wrap(0), abi.encode(0, amountToWithdraw), recipient);
+    vault.specialWithdraw(
+      positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), recipient
+    );
     // Funds after withdraw
     (, balances,) = vault.position(positionId);
     assertEq(erc20.balanceOf(recipient), amountToWithdraw);
@@ -1504,7 +1506,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     vm.prank(operator);
     vm.expectEmit();
     emit PositionWithdrawn(positionId, tokens, CommonUtils.arrayOf(amountToWithdraw), recipient);
-    vault.specialWithdraw(positionId, SpecialWithdrawalCode.wrap(0), abi.encode(0, amountToWithdraw), recipient);
+    vault.specialWithdraw(
+      positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), recipient
+    );
 
     // Funds after withdraw
     (, balances,) = vault.position(positionId);
@@ -1535,7 +1539,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
       )
     );
     vm.prank(operator);
-    vault.specialWithdraw(positionId, SpecialWithdrawalCode.wrap(0), abi.encode(0, amountToWithdraw), recipient);
+    vault.specialWithdraw(
+      positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), recipient
+    );
   }
 
   function test_specialWithdraw_CheckRewards() public {
@@ -1622,7 +1628,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     uint256[] memory intendendWithdraw = CommonUtils.arrayOf(amountToWithdraw1, 0);
 
     vm.prank(operator);
-    vault.specialWithdraw(positionId1, SpecialWithdrawalCode.wrap(0), abi.encode(0, amountToWithdraw1), recipient);
+    vault.specialWithdraw(
+      positionId1, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw1), abi.encode(0), recipient
+    );
 
     // UPDATE SHARES
     //Shares: 5
@@ -1644,7 +1652,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     intendendWithdraw[1] = amountToWithdraw1;
 
     vm.prank(operator);
-    vault.specialWithdraw(positionId1, SpecialWithdrawalCode.wrap(0), abi.encode(1, amountToWithdraw1), recipient);
+    vault.specialWithdraw(
+      positionId1, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw1), abi.encode(1), recipient
+    );
 
     (, balances1,) = vault.position(positionId1);
     assertApproxEqAbs(amountToDeposit1 - amountToWithdraw1, balances1[0], 1);


### PR DESCRIPTION
We are now making some changes to `specialWithdraw`. The idea is to add make information more explicit in both input params and return value