### PR TITLE
refactor: remove positions strategy (breaking change)

### DIFF
--- a/src/interfaces/IEarnVault.sol
+++ b/src/interfaces/IEarnVault.sol
@@ -83,23 +83,17 @@ interface IEarnVault is INFTPermissions {
   function NFT_DESCRIPTOR() external view returns (IEarnNFTDescriptor);
 
   /**
-   * @notice Returns the strategy chosen by the given position
-   * @param positionId The position to check
-   * @return strategyId The strategy chosen by the given position. Will return 0 if the position doesn't exist
-   */
-  function positionsStrategy(uint256 positionId) external view returns (StrategyId strategyId);
-
-  /**
    * @notice Returns a summary of the position's balances
    * @param positionId The position to check the balances for
    * @return tokens All of the position's tokens
    * @return balances Total balance of each token
-   * @return strategy The position's strategy
+   * @return strategyId The position's strategy id
+   * @return strategy The position's strategy address
    */
   function position(uint256 positionId)
     external
     view
-    returns (address[] memory tokens, uint256[] memory balances, IEarnStrategy strategy);
+    returns (address[] memory tokens, uint256[] memory balances, StrategyId strategyId, IEarnStrategy strategy);
 
   /**
    * @notice Returns if deposits and paused

--- a/src/vault/EarnVault.sol
+++ b/src/vault/EarnVault.sol
@@ -81,24 +81,22 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
   receive() external payable { }
 
   /// @inheritdoc IEarnVault
-  function positionsStrategy(uint256 positionId) external view returns (StrategyId strategyId) {
-    // slither-disable-next-line unused-return
-    (strategyId,) = _positions.read(positionId);
-  }
-
-  /// @inheritdoc IEarnVault
-  function position(uint256 positionId) external view returns (address[] memory, uint256[] memory, IEarnStrategy) {
+  function position(uint256 positionId)
+    external
+    view
+    returns (address[] memory, uint256[] memory, StrategyId, IEarnStrategy)
+  {
     (
       uint256 positionAssetBalance,
       CalculatedDataForToken[] memory calculatedData,
-      ,
+      StrategyId strategyId,
       IEarnStrategy strategy,
       ,
       ,
       address[] memory tokens,
     ) = _loadCurrentState(positionId);
     uint256[] memory balances = calculatedData.extractBalances(positionAssetBalance);
-    return (tokens, balances, strategy);
+    return (tokens, balances, strategyId, strategy);
   }
 
   /// @inheritdoc IEarnVault
@@ -665,10 +663,9 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
   )
     internal
   {
-    if (
-      calculatedData.newStrategyLossAccum != YieldMath.LOSS_ACCUM_INITIAL
-        || calculatedData.newStrategyCompleteLossEvents != 0
-    ) {
+    bool strategyHadLoss = calculatedData.newStrategyLossAccum != YieldMath.LOSS_ACCUM_INITIAL
+      || calculatedData.newStrategyCompleteLossEvents != 0;
+    if (strategyHadLoss) {
       _strategyYieldLossData.update({
         strategyId: strategyId,
         token: token,
@@ -681,28 +678,17 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
         newLossAccum: calculatedData.newStrategyLossAccum,
         newCompleteLossEvents: calculatedData.newStrategyCompleteLossEvents
       });
-      _updateYieldData({
-        positionId: positionId,
-        strategyId: strategyId,
-        positionShares: positionShares,
-        token: token,
-        calculatedData: calculatedData,
-        withdrawn: withdrawn,
-        newStrategyBalance: newStrategyBalance,
-        strategyHadLoss: true
-      });
-    } else {
-      _updateYieldData({
-        positionId: positionId,
-        strategyId: strategyId,
-        positionShares: positionShares,
-        token: token,
-        calculatedData: calculatedData,
-        withdrawn: withdrawn,
-        newStrategyBalance: newStrategyBalance,
-        strategyHadLoss: false
-      });
     }
+    _updateYieldData({
+      positionId: positionId,
+      strategyId: strategyId,
+      positionShares: positionShares,
+      token: token,
+      calculatedData: calculatedData,
+      withdrawn: withdrawn,
+      newStrategyBalance: newStrategyBalance,
+      strategyHadLoss: strategyHadLoss
+    });
   }
 
   /// @inheritdoc ERC721

--- a/test/gas/vault/Gas_EarnVault_OneToken_OnePosition.t.sol
+++ b/test/gas/vault/Gas_EarnVault_OneToken_OnePosition.t.sol
@@ -33,7 +33,7 @@ contract GasEarnVaultOneTokenOnePosition is BaseEarnVaultGasTest {
       strategyId, address(erc20), amountToDeposit, address(this), PermissionUtils.buildEmptyPermissionSet(), "", ""
     );
 
-    (tokens,,) = vault.position(positionId);
+    (tokens,,,) = vault.position(positionId);
     intendedToWithdraw = CommonUtils.arrayOf(amountToWithdraw);
   }
 

--- a/test/gas/vault/Gas_EarnVault_ThreeTokens_OnePosition.t.sol
+++ b/test/gas/vault/Gas_EarnVault_ThreeTokens_OnePosition.t.sol
@@ -30,7 +30,7 @@ contract GasEarnVaultThreeTokensOnePosition is BaseEarnVaultGasTest {
       strategyId, address(erc20), amountToDeposit, address(this), PermissionUtils.buildEmptyPermissionSet(), "", ""
     );
     anotherErc20.mint(address(strategy), amountToReward);
-    (tokens,,) = vault.position(positionId);
+    (tokens,,,) = vault.position(positionId);
     intendedToWithdrawRewards = CommonUtils.arrayOf(0, amountToWithdraw, 0);
   }
 

--- a/test/gas/vault/Gas_EarnVault_TwoTokens_ManyPositions_WithLosses.t.sol
+++ b/test/gas/vault/Gas_EarnVault_TwoTokens_ManyPositions_WithLosses.t.sol
@@ -35,7 +35,7 @@ contract GasEarnVaultTwoTokensManyPositionsWithLosses is BaseEarnVaultGasTest {
       anotherErc20.burn(address(strategy), amountToLose);
     }
 
-    (tokens,,) = vault.position(positionId);
+    (tokens,,,) = vault.position(positionId);
     intendedToWithdrawRewards = CommonUtils.arrayOf(0, amountToWithdraw);
   }
 

--- a/test/gas/vault/Gas_EarnVault_TwoTokens_OnePosition.t.sol
+++ b/test/gas/vault/Gas_EarnVault_TwoTokens_OnePosition.t.sol
@@ -32,7 +32,7 @@ contract GasEarnVaultTwoTokensOnePosition is BaseEarnVaultGasTest {
     );
     anotherErc20.mint(address(strategy), amountToReward);
 
-    (tokens,,) = vault.position(positionId);
+    (tokens,,,) = vault.position(positionId);
     intendedToWithdraw = CommonUtils.arrayOf(amountToWithdraw, 0);
     intendedToWithdrawRewards = CommonUtils.arrayOf(0, amountToWithdraw);
   }

--- a/test/gas/vault/Gas_EarnVault_TwoTokens_OnePosition_WithLoss.t.sol
+++ b/test/gas/vault/Gas_EarnVault_TwoTokens_OnePosition_WithLoss.t.sol
@@ -34,7 +34,7 @@ contract GasEarnVaultTwoTokensOnePositionWithLoss is BaseEarnVaultGasTest {
     vault.increasePosition(positionId, address(erc20), amountToIncrease);
     anotherErc20.burn(address(strategy), amountToLose);
 
-    (tokens,,) = vault.position(positionId);
+    (tokens,,,) = vault.position(positionId);
     intendedToWithdrawRewards = CommonUtils.arrayOf(0, amountToWithdraw);
   }
 

--- a/test/invariant/vault/EarnVault.t.sol
+++ b/test/invariant/vault/EarnVault.t.sol
@@ -53,7 +53,7 @@ contract EarnVaultInvariantTest is StdInvariant, StdUtils, StdAssertions {
     uint256[] memory totalBalances = new uint256[](tokens.length);
 
     for (uint256 positionId = 1; positionId <= vault.totalSupply(); positionId++) {
-      (, uint256[] memory balances,) = vault.position(positionId);
+      (, uint256[] memory balances,,) = vault.position(positionId);
       for (uint256 i; i < tokens.length; i++) {
         totalBalances[i] += balances[i];
       }

--- a/test/invariant/vault/handlers/VaultHandler.sol
+++ b/test/invariant/vault/handlers/VaultHandler.sol
@@ -50,7 +50,7 @@ contract VaultHandler is StdUtils {
   function withdraw(uint256 positionIdIndex, uint256 tokenIndex, uint256 amountToWithdraw) external payable {
     if (_vault.totalSupply() != 0) {
       uint256 positionId = bound(positionIdIndex, 1, _vault.totalSupply());
-      (address[] memory tokens, uint256[] memory balances,) = _vault.position(positionId);
+      (address[] memory tokens, uint256[] memory balances,,) = _vault.position(positionId);
       tokenIndex = bound(tokenIndex, 0, tokens.length - 1);
 
       uint256 previousBalance = balances[tokenIndex];
@@ -70,7 +70,7 @@ contract VaultHandler is StdUtils {
   function specialWithdraw(uint256 positionId, uint256 tokenIndex, uint256 amountToWithdraw) external payable {
     if (_vault.totalSupply() != 0) {
       positionId = bound(positionId, 1, _vault.totalSupply());
-      (address[] memory tokens, uint256[] memory balances,) = _vault.position(positionId);
+      (address[] memory tokens, uint256[] memory balances,,) = _vault.position(positionId);
       tokenIndex = bound(tokenIndex, 0, tokens.length - 1);
 
       uint256 previousBalance = balances[tokenIndex];

--- a/test/unit/vault/EarnVault.t.sol
+++ b/test/unit/vault/EarnVault.t.sol
@@ -228,13 +228,14 @@ contract EarnVaultTest is PRBTest, StdUtils {
     // NFTPermissions
     checkPermissions(positionId, permissions);
     // Earn
-    (address[] memory tokens, uint256[] memory balances, IEarnStrategy positionStrategy) = vault.position(positionId);
+    (address[] memory tokens, uint256[] memory balances, StrategyId returnedStrategyId, IEarnStrategy positionStrategy)
+    = vault.position(positionId);
     assertEq(tokens.length, 1);
     assertEq(tokens[0], Token.NATIVE_TOKEN);
     assertEq(address(positionStrategy), address(strategy));
     assertEq(balances.length, 1);
     assertEq(balances[0], amountToDeposit);
-    assertEq(StrategyId.unwrap(vault.positionsStrategy(positionId)), StrategyId.unwrap(strategyId));
+    assertEq(StrategyId.unwrap(returnedStrategyId), StrategyId.unwrap(strategyId));
     // Funds
     assertEq(address(this).balance, 0);
     assertEq(address(strategy).balance, amountToDeposit);
@@ -269,13 +270,14 @@ contract EarnVaultTest is PRBTest, StdUtils {
     // NFTPermissions
     checkPermissions(positionId, permissions);
     // Earn
-    (address[] memory tokens, uint256[] memory balances, IEarnStrategy positionStrategy) = vault.position(positionId);
+    (address[] memory tokens, uint256[] memory balances, StrategyId returnedStrategyId, IEarnStrategy positionStrategy)
+    = vault.position(positionId);
     assertEq(tokens.length, 1);
     assertEq(tokens[0], address(erc20));
     assertEq(address(positionStrategy), address(strategy));
     assertEq(balances.length, 1);
     assertEq(balances[0], amountToDeposit);
-    assertEq(StrategyId.unwrap(vault.positionsStrategy(positionId)), StrategyId.unwrap(strategyId));
+    assertEq(StrategyId.unwrap(returnedStrategyId), StrategyId.unwrap(strategyId));
     // Funds
     assertEq(erc20.balanceOf(address(this)), 0);
     assertEq(erc20.balanceOf(address(strategy)), amountToDeposit);
@@ -314,13 +316,14 @@ contract EarnVaultTest is PRBTest, StdUtils {
     // NFTPermissions
     checkPermissions(positionId, permissions);
     // Earn
-    (address[] memory tokens, uint256[] memory balances, IEarnStrategy positionStrategy) = vault.position(positionId);
+    (address[] memory tokens, uint256[] memory balances, StrategyId returnedStrategyId, IEarnStrategy positionStrategy)
+    = vault.position(positionId);
     assertEq(tokens.length, 1);
     assertEq(tokens[0], address(erc20));
     assertEq(address(positionStrategy), address(strategy));
     assertEq(balances.length, 1);
     assertEq(balances[0], amountToDeposit);
-    assertEq(StrategyId.unwrap(vault.positionsStrategy(positionId)), StrategyId.unwrap(strategyId));
+    assertEq(StrategyId.unwrap(returnedStrategyId), StrategyId.unwrap(strategyId));
     // Funds
     assertEq(erc20.balanceOf(address(this)), 0);
     assertEq(erc20.balanceOf(address(strategy)), amountToDeposit);
@@ -361,10 +364,10 @@ contract EarnVaultTest is PRBTest, StdUtils {
     // ERC721
     assertEq(vault.totalSupply(), 2);
     // Earn
-    (, uint256[] memory balances1,) = vault.position(positionId1);
+    (, uint256[] memory balances1,,) = vault.position(positionId1);
     assertEq(balances1.length, 1);
     assertEq(balances1[0], amountToDeposit1);
-    (, uint256[] memory balances2,) = vault.position(positionId2);
+    (, uint256[] memory balances2,,) = vault.position(positionId2);
     assertEq(balances2.length, 1);
     assertEq(balances2[0], amountToDeposit2);
     // Funds
@@ -461,7 +464,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] = 10;
     totalShares = 10;
 
-    (, uint256[] memory balances1,) = vault.position(positionId1);
+    (, uint256[] memory balances1,,) = vault.position(positionId1);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances1[1], 1);
 
@@ -476,11 +479,11 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[1];
 
     // Earn
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertEq(balances1.length, 2);
     assertEq(balances1[0], amountToDeposit1);
 
-    (, uint256[] memory balances2,) = vault.position(positionId2);
+    (, uint256[] memory balances2,,) = vault.position(positionId2);
     assertEq(balances2.length, 2);
     assertEq(balances2[0], amountToDeposit2);
 
@@ -498,9 +501,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[2] = 20;
     totalShares += shares[2];
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, uint256[] memory balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, uint256[] memory balances3,,) = vault.position(positionId3);
 
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
@@ -517,10 +520,10 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[3] = 20;
     totalShares += shares[3];
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, balances3,) = vault.position(positionId3);
-    (, uint256[] memory balances4,) = vault.position(positionId4);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, balances3,,) = vault.position(positionId3);
+    (, uint256[] memory balances4,,) = vault.position(positionId4);
 
     //LAST SNAPSHOT
 
@@ -563,7 +566,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] = 100;
     totalShares += shares[0];
 
-    (, uint256[] memory balances1,) = vault.position(positionId1);
+    (, uint256[] memory balances1,,) = vault.position(positionId1);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances1[1], 1);
 
@@ -578,11 +581,11 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[1];
 
     // Earn
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertEq(balances1.length, 2);
     assertEq(balances1[0], amountToDeposit1);
 
-    (, uint256[] memory balances2,) = vault.position(positionId2);
+    (, uint256[] memory balances2,,) = vault.position(positionId2);
     assertEq(balances2.length, 2);
     assertEq(balances2[0], amountToDeposit2);
 
@@ -600,9 +603,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[2] = 50;
     totalShares += shares[2];
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, uint256[] memory balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, uint256[] memory balances3,,) = vault.position(positionId3);
 
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
@@ -619,10 +622,10 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[3];
     anotherErc20.mint(address(strategy), 350_000);
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, balances3,) = vault.position(positionId3);
-    (, uint256[] memory balances4,) = vault.position(positionId4);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, balances3,,) = vault.position(positionId3);
+    (, uint256[] memory balances4,,) = vault.position(positionId4);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances1[1], 1);
     assertApproxEqAbs(rewards[1], balances2[1], 1);
@@ -662,7 +665,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] = 100;
     totalShares += shares[0];
 
-    (, uint256[] memory balances1,) = vault.position(positionId1);
+    (, uint256[] memory balances1,,) = vault.position(positionId1);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances1[1], 1);
 
@@ -677,11 +680,11 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[1];
 
     // Earn
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertEq(balances1.length, 2);
     assertEq(balances1[0], amountToDeposit1);
 
-    (, uint256[] memory balances2,) = vault.position(positionId2);
+    (, uint256[] memory balances2,,) = vault.position(positionId2);
     assertEq(balances2.length, 2);
     assertEq(balances2[0], amountToDeposit2);
 
@@ -699,9 +702,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[2] = 50;
     totalShares += shares[2];
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, uint256[] memory balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, uint256[] memory balances3,,) = vault.position(positionId3);
 
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
@@ -718,10 +721,10 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[3];
     anotherErc20.mint(address(strategy), 350_000);
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, balances3,) = vault.position(positionId3);
-    (, uint256[] memory balances4,) = vault.position(positionId4);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, balances3,,) = vault.position(positionId3);
+    (, uint256[] memory balances4,,) = vault.position(positionId4);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances1[1], 1);
     assertApproxEqAbs(rewards[1], balances2[1], 1);
@@ -780,7 +783,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] = amountToDeposit1;
     totalShares += shares[0];
 
-    (, balances[0],) = vault.position(positionIds[0]);
+    (, balances[0],,) = vault.position(positionIds[0]);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances[0][1], 1);
 
@@ -867,7 +870,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       }
     }
 
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertApproxEqAbs(0, balances1[1], 1);
   }
 
@@ -890,7 +893,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       vault.createPosition(strategyId, address(erc20), amountToDeposit, positionOwner, permissions, creationData, misc);
 
     // Funds before withdraw
-    (address[] memory tokens, uint256[] memory balances,) = vault.position(positionId);
+    (address[] memory tokens, uint256[] memory balances,,) = vault.position(positionId);
     assertEq(erc20.balanceOf(address(strategy)), amountToDeposit);
     assertEq(balances[0], amountToDeposit);
 
@@ -905,7 +908,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     vault.withdraw(positionId, tokens, CommonUtils.arrayOf(amountToWithdraw), recipient);
 
     // Funds after withdraw
-    (, balances,) = vault.position(positionId);
+    (, balances,,) = vault.position(positionId);
     assertEq(erc20.balanceOf(recipient), amountToWithdraw != type(uint256).max ? amountToWithdraw : amountToDeposit);
     assertEq(
       erc20.balanceOf(address(strategy)), amountToWithdraw != type(uint256).max ? amountToDeposit - amountToWithdraw : 0
@@ -934,7 +937,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     );
 
     // Funds before withdraw
-    (address[] memory tokens, uint256[] memory balances,) = vault.position(positionId);
+    (address[] memory tokens, uint256[] memory balances,,) = vault.position(positionId);
     assertEq(address(strategy).balance, amountToDeposit);
     assertEq(balances[0], amountToDeposit);
 
@@ -949,7 +952,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     vault.withdraw(positionId, tokens, CommonUtils.arrayOf(amountToWithdraw), recipient);
 
     // Funds after withdraw
-    (, balances,) = vault.position(positionId);
+    (, balances,,) = vault.position(positionId);
     assertEq(recipient.balance, amountToWithdraw != type(uint256).max ? amountToWithdraw : amountToDeposit);
     assertEq(address(strategy).balance, amountToWithdraw != type(uint256).max ? amountToDeposit - amountToWithdraw : 0);
     assertEq(balances[0], amountToWithdraw != type(uint256).max ? amountToDeposit - amountToWithdraw : 0);
@@ -970,7 +973,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     (uint256 positionId,) =
       vault.createPosition(strategyId, address(erc20), amountToDeposit, positionOwner, permissions, creationData, misc);
 
-    (address[] memory tokens,,) = vault.position(positionId);
+    (address[] memory tokens,,,) = vault.position(positionId);
 
     vm.prank(operator);
     vm.expectRevert(abi.encodeWithSelector(IEarnVault.InsufficientFunds.selector));
@@ -991,7 +994,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     (uint256 positionId,) =
       vault.createPosition(strategyId, address(erc20), amountToDeposit, positionOwner, permissions, creationData, misc);
 
-    (address[] memory tokens,,) = vault.position(positionId);
+    (address[] memory tokens,,,) = vault.position(positionId);
 
     vm.expectRevert(
       abi.encodeWithSelector(
@@ -1038,7 +1041,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
 
     (uint256 positionId,) =
       vault.createPosition(strategyId, address(erc20), amountToDeposit, positionOwner, permissions, creationData, misc);
-    (address[] memory tokens,,) = vault.position(positionId);
+    (address[] memory tokens,,,) = vault.position(positionId);
 
     uint256[] memory intendendWithdraw = CommonUtils.arrayOf(amountToWithdraw, amountToWithdraw);
 
@@ -1077,7 +1080,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] = 10;
     totalShares = 10;
 
-    (, uint256[] memory balances1,) = vault.position(positionId1);
+    (, uint256[] memory balances1,,) = vault.position(positionId1);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances1[1], 1);
 
@@ -1092,11 +1095,11 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[1];
 
     // Earn
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertEq(balances1.length, 2);
     assertEq(balances1[0], amountToDeposit1);
 
-    (, uint256[] memory balances2,) = vault.position(positionId2);
+    (, uint256[] memory balances2,,) = vault.position(positionId2);
     assertEq(balances2.length, 2);
     assertEq(balances2[0], amountToDeposit2);
 
@@ -1114,9 +1117,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[2] = 20;
     totalShares += shares[2];
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, uint256[] memory balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, uint256[] memory balances3,,) = vault.position(positionId3);
 
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
@@ -1139,9 +1142,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] -= 5;
     totalShares -= 5;
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, balances3,,) = vault.position(positionId3);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
     assertApproxEqAbs(amountToDeposit1 - amountToWithdraw1, balances1[0], 1);
@@ -1155,7 +1158,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     vm.prank(operator);
     vault.withdraw(positionId1, strategyTokens, intendendWithdraw, recipient);
 
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertApproxEqAbs(amountToDeposit1 - amountToWithdraw1, balances1[0], 1);
 
     //Rewards have to be calculated with previous shares and balance
@@ -1184,7 +1187,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       vault.createPosition(strategyId, address(erc20), amountToDeposit, positionOwner, permissions, creationData, misc);
 
     // Funds before increase
-    (, uint256[] memory balances,) = vault.position(positionId);
+    (, uint256[] memory balances,,) = vault.position(positionId);
     assertEq(erc20.balanceOf(address(strategy)), amountToDeposit);
     assertEq(balances[0], amountToDeposit);
 
@@ -1202,7 +1205,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     vault.increasePosition(positionId, address(erc20), amountToIncrease);
 
     // Funds after increase
-    (, balances,) = vault.position(positionId);
+    (, balances,,) = vault.position(positionId);
     assertEq(
       erc20.balanceOf(operator), amountToIncrease != type(uint256).max ? previousOperatorBalance - amountToIncrease : 0
     );
@@ -1236,7 +1239,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     );
 
     // Funds before increase
-    (, uint256[] memory balances,) = vault.position(positionId);
+    (, uint256[] memory balances,,) = vault.position(positionId);
     assertEq(address(strategy).balance, amountToDeposit);
     assertEq(balances[0], amountToDeposit);
 
@@ -1250,7 +1253,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     vault.increasePosition{ value: amountToIncrease }(positionId, Token.NATIVE_TOKEN, amountToIncrease);
 
     // Funds after increase
-    (, balances,) = vault.position(positionId);
+    (, balances,,) = vault.position(positionId);
     assertEq(operator.balance, previousOperatorBalance - amountToIncrease);
     assertEq(address(strategy).balance, previousStrategyBalance + amountToIncrease);
     assertEq(balances[0], amountToDeposit + amountToIncrease);
@@ -1403,7 +1406,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] = 10;
     totalShares = 10;
 
-    (, uint256[] memory balances1,) = vault.position(positionId1);
+    (, uint256[] memory balances1,,) = vault.position(positionId1);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
     (uint256 positionId2,) =
@@ -1417,8 +1420,8 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[1];
 
     // Earn
-    (, balances1,) = vault.position(positionId1);
-    (, uint256[] memory balances2,) = vault.position(positionId2);
+    (, balances1,,) = vault.position(positionId1);
+    (, uint256[] memory balances2,,) = vault.position(positionId2);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
     (uint256 positionId3,) =
@@ -1430,9 +1433,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[2] = 20;
     totalShares += shares[2];
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, uint256[] memory balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, uint256[] memory balances3,,) = vault.position(positionId3);
 
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
@@ -1447,9 +1450,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] += 10;
     totalShares += 10;
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, balances3,,) = vault.position(positionId3);
 
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
@@ -1476,7 +1479,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       vault.createPosition(strategyId, address(erc20), amountToDeposit, positionOwner, permissions, creationData, misc);
 
     // Funds before withdraw
-    (address[] memory tokens, uint256[] memory balances,) = vault.position(positionId);
+    (address[] memory tokens, uint256[] memory balances,,) = vault.position(positionId);
     assertEq(erc20.balanceOf(address(strategy)), amountToDeposit);
     assertEq(balances[0], amountToDeposit);
 
@@ -1487,7 +1490,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), recipient
     );
     // Funds after withdraw
-    (, balances,) = vault.position(positionId);
+    (, balances,,) = vault.position(positionId);
     assertEq(erc20.balanceOf(recipient), amountToWithdraw);
     assertEq(erc20.balanceOf(address(strategy)), amountToDeposit - amountToWithdraw);
     assertEq(balances[0], amountToDeposit - amountToWithdraw);
@@ -1512,7 +1515,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     );
 
     // Funds before withdraw
-    (address[] memory tokens, uint256[] memory balances,) = vault.position(positionId);
+    (address[] memory tokens, uint256[] memory balances,,) = vault.position(positionId);
     assertEq(address(strategy).balance, amountToDeposit);
     assertEq(balances[0], amountToDeposit);
 
@@ -1524,7 +1527,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     );
 
     // Funds after withdraw
-    (, balances,) = vault.position(positionId);
+    (, balances,,) = vault.position(positionId);
     assertEq(recipient.balance, amountToWithdraw);
     assertEq(address(strategy).balance, amountToDeposit - amountToWithdraw);
     assertEq(balances[0], amountToDeposit - amountToWithdraw);
@@ -1587,7 +1590,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] = 10;
     totalShares = 10;
 
-    (, uint256[] memory balances1,) = vault.position(positionId1);
+    (, uint256[] memory balances1,,) = vault.position(positionId1);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
     assertApproxEqAbs(rewards[0], balances1[1], 1);
 
@@ -1602,11 +1605,11 @@ contract EarnVaultTest is PRBTest, StdUtils {
     totalShares += shares[1];
 
     // Earn
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertEq(balances1.length, 2);
     assertEq(balances1[0], amountToDeposit1);
 
-    (, uint256[] memory balances2,) = vault.position(positionId2);
+    (, uint256[] memory balances2,,) = vault.position(positionId2);
     assertEq(balances2.length, 2);
     assertEq(balances2[0], amountToDeposit2);
 
@@ -1624,9 +1627,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[2] = 20;
     totalShares += shares[2];
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, uint256[] memory balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, uint256[] memory balances3,,) = vault.position(positionId3);
 
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
@@ -1651,9 +1654,9 @@ contract EarnVaultTest is PRBTest, StdUtils {
     shares[0] -= 5;
     totalShares -= 5;
 
-    (, balances1,) = vault.position(positionId1);
-    (, balances2,) = vault.position(positionId2);
-    (, balances3,) = vault.position(positionId3);
+    (, balances1,,) = vault.position(positionId1);
+    (, balances2,,) = vault.position(positionId2);
+    (, balances3,,) = vault.position(positionId3);
     previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsCreated);
 
     assertApproxEqAbs(amountToDeposit1 - amountToWithdraw1, balances1[0], 1);
@@ -1669,7 +1672,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
       positionId1, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw1), abi.encode(1), recipient
     );
 
-    (, balances1,) = vault.position(positionId1);
+    (, balances1,,) = vault.position(positionId1);
     assertApproxEqAbs(amountToDeposit1 - amountToWithdraw1, balances1[0], 1);
 
     //Rewards have to be calculated with previous shares and balance
@@ -1690,7 +1693,7 @@ contract EarnVaultTest is PRBTest, StdUtils {
     returns (uint256 _previousBalance)
   {
     for (uint8 i; i < positionsLength; i++) {
-      (, balances[i],) = vault.position(positionIds[i]);
+      (, balances[i],,) = vault.position(positionIds[i]);
     }
 
     _previousBalance = takeSnapshot(strategy, previousBalance, totalShares, rewards, shares, positionsLength);


### PR DESCRIPTION
We are now getting rid of `positionsStrategy`, and exposing that information in `position`. Since we already had the data, we can expose it there, and reduce contract size a little more