### PR TITLE
feat: reintroduce positions strategy

### DIFF
--- a/src/interfaces/IEarnVault.sol
+++ b/src/interfaces/IEarnVault.sol
@@ -83,6 +83,14 @@ interface IEarnVault is INFTPermissions {
   function NFT_DESCRIPTOR() external view returns (IEarnNFTDescriptor);
 
   /**
+   * @notice Returns the strategy chosen by the given position
+   * @param positionId The position to check
+   * @return strategyId The strategy chosen by the given position. Will return 0 if the position doesn't exist
+   * @return strategy The strategy's address. Will return the zero address if the position doesn't exist
+   */
+  function positionsStrategy(uint256 positionId) external view returns (StrategyId strategyId, IEarnStrategy strategy);
+
+  /**
    * @notice Returns a summary of the position's balances
    * @param positionId The position to check the balances for
    * @return tokens All of the position's tokens

--- a/src/vault/EarnVault.sol
+++ b/src/vault/EarnVault.sol
@@ -81,6 +81,11 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
   receive() external payable { }
 
   /// @inheritdoc IEarnVault
+  function positionsStrategy(uint256 positionId) external view returns (StrategyId strategyId, IEarnStrategy strategy) {
+    (strategyId,, strategy) = _loadPositionState(positionId);
+  }
+
+  /// @inheritdoc IEarnVault
   function position(uint256 positionId)
     external
     view
@@ -167,14 +172,19 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
     whenNotPaused
     returns (uint256, uint256)
   {
+    IEarnStrategy strategy = STRATEGY_REGISTRY.getStrategy(strategyId);
     (
       ,
       CalculatedDataForToken[] memory calculatedData,
-      IEarnStrategy strategy,
       uint256 totalShares,
       address[] memory tokens,
       uint256[] memory totalBalances
-    ) = _loadCurrentState({ positionId: YieldMath.POSITION_BEING_CREATED, strategyId: strategyId, positionShares: 0 });
+    ) = _loadCurrentState({
+      positionId: YieldMath.POSITION_BEING_CREATED,
+      strategyId: strategyId,
+      strategy: strategy,
+      positionShares: 0
+    });
 
     strategy.validatePositionCreation(msg.sender, strategyValidationData);
 
@@ -375,6 +385,15 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
     _unpause();
   }
 
+  function _loadPositionState(uint256 positionId)
+    internal
+    view
+    returns (StrategyId strategyId, uint256 positionShares, IEarnStrategy strategy)
+  {
+    (strategyId, positionShares) = _positions.read(positionId);
+    strategy = STRATEGY_REGISTRY.getStrategy(strategyId);
+  }
+
   function _loadCurrentState(uint256 positionId)
     internal
     view
@@ -389,14 +408,15 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
       uint256[] memory totalBalances
     )
   {
-    (strategyId, positionShares) = _positions.read(positionId);
-    (positionAssetBalance, calculatedData, strategy, totalShares, tokens, totalBalances) =
-      _loadCurrentState(positionId, strategyId, positionShares);
+    (strategyId, positionShares, strategy) = _loadPositionState(positionId);
+    (positionAssetBalance, calculatedData, totalShares, tokens, totalBalances) =
+      _loadCurrentState(positionId, strategyId, strategy, positionShares);
   }
 
   function _loadCurrentState(
     uint256 positionId,
     StrategyId strategyId,
+    IEarnStrategy strategy,
     uint256 positionShares
   )
     internal
@@ -404,14 +424,12 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
     returns (
       uint256 positionAssetBalance,
       CalculatedDataForToken[] memory calculatedData,
-      IEarnStrategy strategy,
       uint256 totalShares,
       address[] memory tokens,
       uint256[] memory totalBalances
     )
   {
     totalShares = _totalSharesInStrategy[strategyId];
-    strategy = STRATEGY_REGISTRY.getStrategy(strategyId);
     (positionAssetBalance, calculatedData, tokens, totalBalances) = _calculateAllData({
       positionId: positionId,
       strategyId: strategyId,


### PR DESCRIPTION
We are now re-introducing `positionsStrategy`. We realized that if another contract just wanted to figure out the position's strategy, then calling `position` would be to costly

But we still managed to keep the contract size down with a little refactoring 💪 