### PR TITLE
feat: add new event for special withdraw

### DIFF
--- a/src/interfaces/IEarnVault.sol
+++ b/src/interfaces/IEarnVault.sol
@@ -47,6 +47,17 @@ interface IEarnVault is INFTPermissions {
   /// @notice Emitted when a new position is withdrawn
   event PositionWithdrawn(uint256 indexed positionId, address[] tokens, uint256[] withdrawn, address recipient);
 
+  /// @notice Emitted when a new position is withdrawn specially
+  event PositionWithdrawnSpecially(
+    uint256 indexed positionId,
+    address[] tokens,
+    uint256[] balanceChanges,
+    address[] actualWithdrawnTokens,
+    uint256[] actualWithdrawnAmounts,
+    bytes result,
+    address recipient
+  );
+
   /**
    * @notice Returns the role in charge of pausing/unpausing deposits
    * @return The role in charge of pausing/unpausing deposits

--- a/src/vault/EarnVault.sol
+++ b/src/vault/EarnVault.sol
@@ -376,7 +376,9 @@ contract EarnVault is AccessControl, NFTPermissions, Pausable, ReentrancyGuard, 
 
     tokens = tokens_;
 
-    emit PositionWithdrawn(positionId, tokens, balanceChanges, recipient);
+    emit PositionWithdrawnSpecially(
+      positionId, tokens, balanceChanges, actualWithdrawnTokens, actualWithdrawnAmounts, result, recipient
+    );
   }
 
   /// @inheritdoc IEarnVault

--- a/test/unit/vault/EarnVault.t.sol
+++ b/test/unit/vault/EarnVault.t.sol
@@ -51,6 +51,15 @@ contract EarnVaultTest is PRBTest, StdUtils {
   );
 
   event PositionWithdrawn(uint256 indexed positionId, address[] tokens, uint256[] withdrawn, address recipient);
+  event PositionWithdrawnSpecially(
+    uint256 indexed positionId,
+    address[] tokens,
+    uint256[] balanceChanges,
+    address[] actualWithdrawnTokens,
+    uint256[] actualWithdrawnAmounts,
+    bytes result,
+    address recipient
+  );
 
   using StrategyUtils for EarnStrategyRegistryMock;
   using InternalUtils for INFTPermissions.Permission[];
@@ -1485,7 +1494,15 @@ contract EarnVaultTest is PRBTest, StdUtils {
 
     vm.prank(operator);
     vm.expectEmit();
-    emit PositionWithdrawn(positionId, tokens, CommonUtils.arrayOf(amountToWithdraw), recipient);
+    emit PositionWithdrawnSpecially(
+      positionId,
+      tokens,
+      CommonUtils.arrayOf(amountToWithdraw),
+      CommonUtils.arrayOf(address(erc20)),
+      CommonUtils.arrayOf(amountToWithdraw),
+      "0x",
+      recipient
+    );
     vault.specialWithdraw(
       positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), recipient
     );
@@ -1521,7 +1538,15 @@ contract EarnVaultTest is PRBTest, StdUtils {
 
     vm.prank(operator);
     vm.expectEmit();
-    emit PositionWithdrawn(positionId, tokens, CommonUtils.arrayOf(amountToWithdraw), recipient);
+    emit PositionWithdrawnSpecially(
+      positionId,
+      tokens,
+      CommonUtils.arrayOf(amountToWithdraw),
+      CommonUtils.arrayOf(Token.NATIVE_TOKEN),
+      CommonUtils.arrayOf(amountToWithdraw),
+      "0x",
+      recipient
+    );
     vault.specialWithdraw(
       positionId, SpecialWithdrawalCode.wrap(0), CommonUtils.arrayOf(amountToWithdraw), abi.encode(0), recipient
     );


### PR DESCRIPTION
We are now adding a new event `PositionWithdrawnSpecially` for special withdraws. This will allow us to have more data in the case of special withdraws