### PR TITLE
fix: avoid strategy registration frontrunning

### DIFF
--- a/src/interfaces/IEarnStrategyRegistry.sol
+++ b/src/interfaces/IEarnStrategyRegistry.sol
@@ -171,15 +171,14 @@ interface IEarnStrategyRegistry {
   function totalRegistered() external view returns (uint256);
 
   /**
-   * @notice Registers a new strategy
+   * @notice Registers a new strategy. The strategy must be the one to call this function
    * @dev The strategy must report the asset as the first token
    *      The strategy can't be associated to another id
    *      The new strategy must support the expected interface.
    * @param firstOwner The strategy's owner
-   * @param strategy The strategy to register
    * @return The id assigned to the new strategy
    */
-  function registerStrategy(address firstOwner, IEarnStrategy strategy) external returns (StrategyId);
+  function registerStrategy(address firstOwner) external returns (StrategyId);
 
   /**
    * @notice Returns the strategy's owner to the given id

--- a/src/strategy-registry/EarnStrategyRegistry.sol
+++ b/src/strategy-registry/EarnStrategyRegistry.sol
@@ -40,7 +40,8 @@ contract EarnStrategyRegistry is IEarnStrategyRegistry {
   }
 
   /// @inheritdoc IEarnStrategyRegistry
-  function registerStrategy(address firstOwner, IEarnStrategy strategy) external returns (StrategyId strategyId) {
+  function registerStrategy(address firstOwner) external returns (StrategyId strategyId) {
+    IEarnStrategy strategy = IEarnStrategy(msg.sender);
     _revertIfNotStrategy(strategy);
     _revertIfNotAssetAsFirstToken(strategy);
     if (assignedId[strategy] != StrategyIdConstants.NO_STRATEGY) revert StrategyAlreadyRegistered();

--- a/test/mocks/strategies/EarnStrategyDead.sol
+++ b/test/mocks/strategies/EarnStrategyDead.sol
@@ -16,6 +16,10 @@ contract EarnStrategyDead is IEarnStrategy {
   // solhint-disable-next-line no-empty-blocks
   receive() external payable virtual { }
 
+  function registerStrategy(IEarnStrategyRegistry registry_, address owner) external returns (StrategyId) {
+    return registry_.registerStrategy(owner);
+  }
+
   function asset() external view virtual returns (address) {
     revert NotImplemented();
   }

--- a/test/mocks/strategies/EarnStrategyRegistryMock.sol
+++ b/test/mocks/strategies/EarnStrategyRegistryMock.sol
@@ -12,7 +12,8 @@ contract EarnStrategyRegistryMock is IEarnStrategyRegistry {
   mapping(IEarnStrategy strategy => StrategyId strategyId) public assignedId;
   uint96 internal _nextStrategyId = 1;
 
-  function registerStrategy(address, IEarnStrategy strategy) external returns (StrategyId strategyId) {
+  function registerStrategy(address) external returns (StrategyId strategyId) {
+    IEarnStrategy strategy = IEarnStrategy(msg.sender);
     strategyId = StrategyId.wrap(_nextStrategyId++);
     assignedId[strategy] = strategyId;
     getStrategy[strategyId] = strategy;

--- a/test/unit/strategy-registry/EarnStrategyRegistry.t.sol
+++ b/test/unit/strategy-registry/EarnStrategyRegistry.t.sol
@@ -46,7 +46,8 @@ contract EarnStrategyRegistryTest is PRBTest {
     vm.expectEmit();
     emit StrategyRegistered(owner, StrategyIdConstants.INITIAL_STRATEGY_ID, aStrategy);
 
-    StrategyId aRegisteredStrategyId = strategyRegistry.registerStrategy(owner, aStrategy);
+    vm.prank(address(aStrategy));
+    StrategyId aRegisteredStrategyId = strategyRegistry.registerStrategy(owner);
     assertEq(address(strategyRegistry.getStrategy(aRegisteredStrategyId)), address(aStrategy));
     assertEq(owner, strategyRegistry.owner(aRegisteredStrategyId));
     assertTrue(strategyRegistry.assignedId(aStrategy) == aRegisteredStrategyId);
@@ -57,10 +58,12 @@ contract EarnStrategyRegistryTest is PRBTest {
   function test_registerStrategy_RevertWhen_StrategyIsAlreadyRegistered() public {
     IEarnStrategy aStrategy = StrategyUtils.deployStateStrategy(CommonUtils.arrayOf(Token.NATIVE_TOKEN));
 
-    strategyRegistry.registerStrategy(owner, aStrategy);
+    vm.prank(address(aStrategy));
+    strategyRegistry.registerStrategy(owner);
 
     vm.expectRevert(abi.encodeWithSelector(IEarnStrategyRegistry.StrategyAlreadyRegistered.selector));
-    strategyRegistry.registerStrategy(owner, aStrategy);
+    vm.prank(address(aStrategy));
+    strategyRegistry.registerStrategy(owner);
   }
 
   function test_registerStrategy_RevertWhen_AssetIsNotFirstToken() public {
@@ -70,20 +73,24 @@ contract EarnStrategyRegistryTest is PRBTest {
     IEarnStrategy badStrategy = new EarnStrategyBadMock(tokens);
 
     vm.expectRevert(abi.encodeWithSelector(IEarnStrategyRegistry.AssetIsNotFirstToken.selector, badStrategy));
-    strategyRegistry.registerStrategy(owner, badStrategy);
+    vm.prank(address(badStrategy));
+    strategyRegistry.registerStrategy(owner);
   }
 
   function test_registerStrategy_RevertWhen_AddressIsNotStrategy() public {
     IEarnStrategy badStrategy;
     vm.expectRevert(abi.encodeWithSelector(IEarnStrategyRegistry.AddressIsNotStrategy.selector, badStrategy));
-    strategyRegistry.registerStrategy(owner, badStrategy);
+    vm.prank(address(badStrategy));
+    strategyRegistry.registerStrategy(owner);
   }
 
   function test_registerStrategy_MultipleStrategiesRegistered() public {
     IEarnStrategy aStrategy = StrategyUtils.deployStateStrategy(CommonUtils.arrayOf(Token.NATIVE_TOKEN));
     IEarnStrategy anotherStrategy = StrategyUtils.deployStateStrategy(CommonUtils.arrayOf(Token.NATIVE_TOKEN));
-    StrategyId aRegisteredStrategyId = strategyRegistry.registerStrategy(owner, aStrategy);
-    StrategyId anotherRegisteredStrategyId = strategyRegistry.registerStrategy(owner, anotherStrategy);
+    vm.prank(address(aStrategy));
+    StrategyId aRegisteredStrategyId = strategyRegistry.registerStrategy(owner);
+    vm.prank(address(anotherStrategy));
+    StrategyId anotherRegisteredStrategyId = strategyRegistry.registerStrategy(owner);
 
     assertNotEq(
       address(strategyRegistry.getStrategy(aRegisteredStrategyId)),

--- a/test/utils/StrategyUtils.sol
+++ b/test/utils/StrategyUtils.sol
@@ -23,7 +23,7 @@ library StrategyUtils {
   {
     IEarnStrategy.WithdrawalType[] memory withdrawalTypes = new IEarnStrategy.WithdrawalType[](tokens.length);
     strategy = new EarnStrategyStateBalanceMock(tokens, withdrawalTypes);
-    strategyId = registry.registerStrategy(owner, strategy);
+    strategyId = strategy.registerStrategy(registry, owner);
   }
 
   function deployBadMigrationStrategy(
@@ -36,7 +36,7 @@ library StrategyUtils {
   {
     IEarnStrategy.WithdrawalType[] memory withdrawalTypes = new IEarnStrategy.WithdrawalType[](tokens.length);
     strategy = new EarnStrategyStateBalanceBadMigrationMock(tokens, withdrawalTypes);
-    strategyId = registry.registerStrategy(owner, strategy);
+    strategyId = strategy.registerStrategy(registry, owner);
   }
 
   function deployBadPositionValidationStrategy(
@@ -48,7 +48,7 @@ library StrategyUtils {
   {
     IEarnStrategy.WithdrawalType[] memory withdrawalTypes = new IEarnStrategy.WithdrawalType[](tokens.length);
     strategy = new EarnStrategyStateBalanceBadPositionValidationMock(tokens, withdrawalTypes);
-    strategyId = registry.registerStrategy(address(this), strategy);
+    strategyId = strategy.registerStrategy(registry, address(this));
   }
 
   function deployStateStrategy(address[] memory tokens) internal returns (EarnStrategyStateBalanceMock strategy) {
@@ -82,7 +82,7 @@ library StrategyUtils {
   {
     require(tokens.length > 0, "Invalid");
     strategy = new EarnStrategyStateBalanceMock(tokens, withdrawalTypes);
-    strategyId = registry.registerStrategy(address(this), strategy);
+    strategyId = strategy.registerStrategy(registry, address(this));
   }
 
   function deployCustomStrategy(
@@ -93,6 +93,6 @@ library StrategyUtils {
     returns (StrategyId strategyId, EarnStrategyCustomBalanceMock strategy)
   {
     strategy = new EarnStrategyCustomBalanceMock(asset);
-    strategyId = registry.registerStrategy(address(this), strategy);
+    strategyId = strategy.registerStrategy(registry, address(this));
   }
 }


### PR DESCRIPTION
Before this change, strategy registration could be frontrun. For example, Alice could create a strategy S. When she tried to register it, Bob could frontrun her and set himself as the owner. 

_Note: this wouldn't be an issue if the strategy was deployed and registered on the same transaction_

Now, we I think it's unlikely that it would lead to a loss of funds. For example, if Alice were to try to register the strategy by herself and she ended up being frontun, her transaction would revert and she wouldn't get a strategy id. So we think it's unlikely that she would create a position and deposit funds into it. And if she weren't trying to register the strategy yet, it's even more unlikely. Or maybe we have too much confidence in Alice 😅

But this is still an issue that would cause many problems, since it's basically a DoS.

We considered the following options with the team:

1 - Do nothing and document the situation
One option was to simply document this behavior and have strategy creators deploy + register on the same transaction, since then they couldn't be frontrun. We actually do this for our contracts (deploy + register). The problem was in the case of updates. In that scenario, the owner would have to deploy + propose update on the same transaction also, which is possible, but harder

2 - Allow strategies to be registered to multiple ids
We realized the the DoS could happen only because the strategy could be assigned to at most one strategy id. We considered removing this restriction, but we realized many different parts of the Earn ecosystem assume that each strategy has only one id. So this wasn't an viable option

3 - Make the strategy registry permissioned
If the registry was permissioned, then this couldn't happen. While, this fixed the issue, it's something we don't want to do at this time

4 - Add `firstOwner` or `owner` function to the strategy
This could be fixed by adding a new function to the strategy

5 - Move the responsibility of registration to the strategies
So the idea would be to basically change `registerStrategy` to the following:

```
function registerStrategy(address firstOwner) external returns (StrategyId strategyId) {
  IEarnStrategy strategy = IEarnStrategy(msg.sender);
  _revertIfNotStrategy(strategy);
  ...
}
```
By doing this, we are only allowing strategies to register themselves, so frontunning isn't possible. It would be similar to option (4) in the sense that strategy builders would need to write code specially for registration, but we think it's a little more flexible in the sense that:
- It wouldn't be a function that remains public for the rest of the strategy's life
- It can easily be added to the constructor/initialization function
- Or it could be something else that the strategy wants to implement, like a register function on the strategy, that implements access checks

We decided to move on with (5), which is basically this PR. But we wanted to document our rationale