### PR TITLE
fix: set complete loss events when partial loss

### DIFF
--- a/src/vault/libraries/YieldMath.sol
+++ b/src/vault/libraries/YieldMath.sol
@@ -81,6 +81,7 @@ library YieldMath {
        */
       newStrategyYieldAccum =
         previousStrategyYieldAccum.mulDiv(newStrategyLossAccum, previousStrategyLossAccum, Math.Rounding.Floor);
+      newStrategyCompleteLossEvents = previousStrategyCompleteLossEvents;
     } else if (totalShares == 0) {
       return (previousStrategyYieldAccum, previousStrategyLossAccum, previousStrategyCompleteLossEvents);
     } else {


### PR DESCRIPTION
Before this change, when a partial loss happened, we forgot to set `newStrategyCompleteLossEvents`. This meant that it would be reset to 0, instead of continuing to have the same value as before

Now we are fixing it correctly, and adding some tests